### PR TITLE
initialize connectWait in constructor

### DIFF
--- a/lib/consumer.js
+++ b/lib/consumer.js
@@ -73,6 +73,7 @@ function Consumer(options, messageHandler) {
   }
 
   this.options = _.merge({}, defaultOptions, options);
+  this.connectWait = 0;
   this.processMessage = messageHandler;
 }
 


### PR DESCRIPTION
For safety, `connectWait` should be initialized upon `Consumer` construction. If a user calls `connect` after construction and connectivity errors exist, the `handleError` backoff logic does not properly increment the wait time (NaN + n = NaN). 

Indeed, users should be using `start` to start their consumers, but this wasn't obvious at first & the results were explosive. :)
